### PR TITLE
CMake for QE7.4

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -18,8 +18,10 @@ jobs:
               git config --global user.email ${{ secrets.TESTER_EMAIL }}
          - name: Install dependencies
            run: |
+              uname -ra
+              lsb_release -a
               sudo apt-get update
-              sudo apt-get install gfortran libopenmpi-dev libblas-dev liblapack-dev fftw3 fftw3-dev
+              sudo apt-get install gfortran libopenmpi-dev libblas-dev liblapack-dev libfftw3 fftw3-dev
          - name: Checkout koopmans-qe-utils
            uses: actions/checkout@v2
          - name: Checkout q-e

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -19,7 +19,7 @@ jobs:
          - name: Install dependencies
            run: |
               sudo apt-get update
-              sudo apt-get install gfortran libopenmpi-dev libblas-dev liblapack-dev fftw3-dev
+              sudo apt-get install gfortran libopenmpi-dev libblas-dev liblapack-dev fftw3 fftw3-dev
          - name: Checkout koopmans-qe-utils
            uses: actions/checkout@v2
          - name: Checkout q-e

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -35,7 +35,7 @@ jobs:
               cd q-e
               mkdir build
               cd build
-              cmake .. -DQE_ENABLE_FOX=ON
+              cmake .. -DQE_ENABLE_FOX=OFF
               make -j
          - name: Build koopmans-qe-utils
            run: |

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -18,7 +18,6 @@ jobs:
               git config --global user.email ${{ secrets.TESTER_EMAIL }}
          - name: Install dependencies
            run: |
-              uname -ra
               lsb_release -a
               sudo apt-get update
               sudo apt-get install gfortran libopenmpi-dev libblas-dev liblapack-dev libfftw3-dev

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -21,7 +21,7 @@ jobs:
               uname -ra
               lsb_release -a
               sudo apt-get update
-              sudo apt-get install gfortran libopenmpi-dev libblas-dev liblapack-dev libfftw3 fftw3-dev
+              sudo apt-get install gfortran libopenmpi-dev libblas-dev liblapack-dev libfftw3-dev
          - name: Checkout koopmans-qe-utils
            uses: actions/checkout@v2
          - name: Checkout q-e

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,11 +116,6 @@ set(QE_FFTW_VENDOR "AUTO" CACHE
 set(QE_ENABLE_SANITIZER "none" CACHE STRING "none,asan,ubsan,tsan,msan")
 set(QE_ENABLE_PLUGINS "" CACHE STRING "Semicolon-separated list of plugins")
 set(QE_LIBRARY_PATH "" CACHE STRING "Location of QE libraries")
-if(FoX_ROOT)
-    set(QE_FoX_INTERNAL OFF)
-endif()
-option(QE_FoX_INTERNAL
-    "enable FoX intenal library" ON)
 if(WANNIER90_ROOT)
     set(QE_WANNIER90_INTERNAL OFF)
 endif()
@@ -537,20 +532,6 @@ if(QE_ENABLE_HDF5)
         INTERFACE
             ${HDF5_C_DEFINITIONS})
 endif(QE_ENABLE_HDF5)
-
-###########################################################
-# FoX
-###########################################################
-if(NOT FoX_ROOT)
-    set(FoX_ROOT "${QE_ROOT}/build/lib/")
-endif()
-add_library(qe_fox INTERFACE)
-find_package(FoX REQUIRED)
-target_link_libraries(qe_fox INTERFACE FoX::FoX)
-if(NOT FoX_FOUND)
-    message(FATAL_ERROR "Failed to find FoX")
-endif()
-###########################################################
 
 ###########################################################
 # External FFT library

--- a/cmake/FindEspresso.cmake
+++ b/cmake/FindEspresso.cmake
@@ -53,7 +53,7 @@ endif()
 
 # Construct a list of Quantum ESPRESSO static libraries
 set(QE_LIBRARIES "")
-foreach(libname qe_pw qe_pp qe_kssolver_dense qe_modules qe_modules_c qe_xclib qe_libbeef qe_lax qe_upflib qe_xml qe_utilx qe_utilx_c qe_fftx qe_dftd3 qe_devxlib mbd)
+foreach(libname qe_pw qe_pp qe_kssolver_dense qe_modules qe_modules_c qe_xclib qe_libbeef qe_lax qe_device_lapack qe_upflib qe_xml qe_utilx qe_utilx_c qe_fftx qe_fftx_c qe_dftd3 qe_devxlib mbd)
     set(libvar "lib${libname}")
     find_library(${libvar} NAMES ${libname}
         PATHS ${QE_ROOT}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,7 +27,7 @@ target_link_libraries(qe_merge_evc_exe)
 set(src_wann2kcp_x wann2kcp.f90)
 qe_add_executable(qe_wann2kcp_exe ${src_wann2kcp_x})
 set_target_properties(qe_wann2kcp_exe PROPERTIES OUTPUT_NAME wann2kcp.x)
-target_link_libraries(qe_wann2kcp_exe PRIVATE qe_koopmans_utils ${QE_LIBRARIES} qe_fox qe_lapack qe_mpi_fortran qe_openmp_fortran qe_hdf5_fortran qe_ext_fft)
+target_link_libraries(qe_wann2kcp_exe PRIVATE qe_koopmans_utils ${QE_LIBRARIES} qe_lapack qe_mpi_fortran qe_openmp_fortran qe_hdf5_fortran qe_ext_fft)
 
 ###########################################################
 # epsilon.x
@@ -35,6 +35,6 @@ target_link_libraries(qe_wann2kcp_exe PRIVATE qe_koopmans_utils ${QE_LIBRARIES} 
 set(src_epsilon_x epsilon.f90)
 qe_add_executable(qe_epsilon_exe ${src_epsilon_x})
 set_target_properties(qe_epsilon_exe PROPERTIES OUTPUT_NAME epsilon.x)
-target_link_libraries(qe_epsilon_exe PRIVATE qe_koopmans_utils ${QE_LIBRARIES} qe_fox qe_lapack qe_mpi_fortran qe_openmp_fortran qe_hdf5_fortran qe_ext_fft)
+target_link_libraries(qe_epsilon_exe PRIVATE qe_koopmans_utils ${QE_LIBRARIES} qe_lapack qe_mpi_fortran qe_openmp_fortran qe_hdf5_fortran qe_ext_fft)
 
 qe_install_targets(qe_merge_evc_exe qe_wann2kcp_exe qe_epsilon_exe)


### PR DESCRIPTION
At the moment, the `cmake` build process for the utilities is broken due to changes introduced in QE 7.4. Some dependencies have been removed, while others need to be added. This merge request addresses and resolves those issues.

The changes have been tested on Eiger with the Cray Intel toolchain, as well as on a local workstation using GNU Fortran.

Additionally, the CI tests were failing on the latest Ubuntu release due to an incorrect command used to install the FFTW3 library. This has now been fixed.